### PR TITLE
Fix stale @starknet-react/core import and cairo test arity mismatch

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { useScaffoldReadContract } from "~~/hooks/scaffold-stark/useScaffoldReadContract";
 import { useScaffoldEventHistory } from "~~/hooks/scaffold-stark/useScaffoldEventHistory";
 import { useScaffoldMultiWriteContract } from "~~/hooks/scaffold-stark/useScaffoldMultiWriteContract";
-import { useBlockNumber } from "@starknet-react/core";
+import { useBlockNumber } from "@starknet-start/react";
 import { useDeployedContractInfo } from "~~/hooks/scaffold-stark/useDeployedContractInfo";
 import { useScaffoldWriteContract } from "~~/hooks/scaffold-stark/useScaffoldWriteContract";
 import { useTargetNetwork } from "~~/hooks/scaffold-stark/useTargetNetwork";

--- a/packages/snfoundry/contracts/tests/test_contract.cairo
+++ b/packages/snfoundry/contracts/tests/test_contract.cairo
@@ -107,7 +107,10 @@ fn test_set_greeting_no_allowance() {
     let new_greeting: ByteArray = "Learn Scaffold-Stark 2! :)";
 
     cheat_caller_address(your_contract_address, user, CheatSpan::TargetCalls(1));
-    your_contract_dispatcher.set_greeting(new_greeting.clone(), Option::Some(500));
+    your_contract_dispatcher
+        .set_greeting(
+            new_greeting.clone(), Option::Some(500), Option::Some(ETH_TOKEN_CONTRACT_ADDRESS),
+        );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- `app/page.tsx:8` imported `useBlockNumber` from `@starknet-react/core`, the old package name. The repo migrated to `@starknet-start/react` (declared as `^1.0.8` in package.json); every other hook usage already points there. Repointed the import — `@starknet-start/react` does export `useBlockNumber`, verified against the package's type declarations.
- `contracts/tests/test_contract.cairo:110` called `set_greeting(new_greeting, Option::Some(500))` with 2 args; the contract signature takes 3 (`new_greeting`, `option_amount`, `option_token`), causing a compile error (E2030) that failed the whole test suite before any test could run. Added the missing token arg (`Option::Some(ETH_TOKEN_CONTRACT_ADDRESS)`, matching the sibling `test_transfer_eth` pattern at line 59) so the call now exercises the intended "insufficient allowance" panic path.

Diff is two lines of source changed (plus the corresponding cairo call reformatting) — no refactors, no unrelated cleanup. `deployedContracts.ts` untouched (D1, out of scope).

## Proof (pasted command output)
**Compile:** `⏭️ Skipping compilation - all contracts are up to date` (contracts/src unchanged by this PR)

**Test:**
```
Collected 5 test(s) from contracts package
Running 0 test(s) from src/
Running 5 test(s) from tests/
[PASS] contracts_integrationtest::test_contract::test_withdraw_not_owner
[PASS] contracts_integrationtest::test_contract::test_set_greetings
[PASS] contracts_integrationtest::test_contract::test_set_greeting_no_allowance
[PASS] contracts_integrationtest::test_contract::test_transfer_eth
[PASS] contracts_integrationtest::test_contract::test_transfer_strk
Tests: 5 passed, 0 failed, 0 ignored, 0 filtered out
```
Compile-clean (E2030 gone) and full pass, including the 3 `#[fork("SEPOLIA_LATEST")]` tests (network was reachable this run).

**next:check-types:** exit 0, clean (verified against a real deploy so the "Strk"|"Eth" narrowing from the empty `deployedContracts.ts` stub isn't masking anything)

**yarn build:** succeeded, all 8 routes generated

**next dev (port 3002):** `curl -o /dev/null -w HTTP_STATUS http://127.0.0.1:3002/` → `HTTP_STATUS:200`

## Test plan
- [x] `yarn compile`
- [x] `yarn test` (5/5 pass)
- [x] `yarn next:check-types` (exit 0)
- [x] `cd packages/nextjs && yarn build`
- [x] `next dev` on port 3002, `curl` `/` → 200