### PR TITLE
Fix stale @starknet-react/core imports and cairo test arity mismatch

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import { useScaffoldReadContract } from "~~/hooks/scaffold-stark/useScaffoldReadContract";
 import { useScaffoldEventHistory } from "~~/hooks/scaffold-stark/useScaffoldEventHistory";
 import { useScaffoldMultiWriteContract } from "~~/hooks/scaffold-stark/useScaffoldMultiWriteContract";
-import { useBlockNumber } from "@starknet-react/core";
+import { useBlockNumber } from "@starknet-start/react";
 import { useDeployedContractInfo } from "~~/hooks/scaffold-stark/useDeployedContractInfo";
 import { useScaffoldWriteContract } from "~~/hooks/scaffold-stark/useScaffoldWriteContract";
 import { useTargetNetwork } from "~~/hooks/scaffold-stark/useTargetNetwork";

--- a/packages/nextjs/app/vesu/page.tsx
+++ b/packages/nextjs/app/vesu/page.tsx
@@ -8,7 +8,7 @@ import { useScaffoldEventHistory } from "~~/hooks/scaffold-stark/useScaffoldEven
 import { useDeployedContractInfo } from "~~/hooks/scaffold-stark/useDeployedContractInfo";
 import { useScaffoldWriteContract } from "~~/hooks/scaffold-stark/useScaffoldWriteContract";
 import { useTargetNetwork } from "~~/hooks/scaffold-stark/useTargetNetwork";
-import { useAccount } from "@starknet-react/core";
+import { useAccount } from "~~/hooks/useAccount";
 import useScaffoldStrkBalance from "~~/hooks/scaffold-stark/useScaffoldStrkBalance";
 
 const Home = () => {

--- a/packages/snfoundry/contracts/tests/test_contract.cairo
+++ b/packages/snfoundry/contracts/tests/test_contract.cairo
@@ -107,7 +107,10 @@ fn test_set_greeting_no_allowance() {
     let new_greeting: ByteArray = "Learn Scaffold-Stark 2! :)";
 
     cheat_caller_address(your_contract_address, user, CheatSpan::TargetCalls(1));
-    your_contract_dispatcher.set_greeting(new_greeting.clone(), Option::Some(500));
+    your_contract_dispatcher
+        .set_greeting(
+            new_greeting.clone(), Option::Some(500), Option::Some(ETH_TOKEN_CONTRACT_ADDRESS),
+        );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- `app/page.tsx:8` imported `useBlockNumber` from `@starknet-react/core`, the old package name (identical fix and byte-identical line to PR #21 on step-2, verified character-for-character).
- `app/vesu/page.tsx:11` imported `useAccount` from the same old package. Repointed to `~~/hooks/useAccount` — the local wrapper every other standalone `useAccount` consumer in the codebase uses (`ConnectedAddress.tsx`, `WriteOnlyFunctionForm.tsx`, `FaucetButton.tsx`, `useAutoConnect.ts`, `useTargetNetwork.ts`, `CustomConnectButton/index.tsx`). This file only destructures `.address`, matching that convention (the two exceptions using the raw package, `Header.tsx` and `NetworkOptions.tsx`, do so because they import multiple hooks — `useNetwork`/`useProvider`/`useSwitchChain` — in one line).
- `contracts/tests/test_contract.cairo:110` — same arity fix as step-2 (byte-identical content, verified via diff).

No refactors, no unrelated cleanup. `deployedContracts.ts` untouched (D1, out of scope).

## Proof (pasted command output)

**Compile:** `⏭️ Skipping compilation - all contracts are up to date`

**Test:**
```
Collected 5 test(s) from contracts package
Running 5 test(s) from tests/
[PASS] contracts_integrationtest::test_contract::test_withdraw_not_owner
[PASS] contracts_integrationtest::test_contract::test_set_greetings
[PASS] contracts_integrationtest::test_contract::test_set_greeting_no_allowance
[PASS] contracts_integrationtest::test_contract::test_transfer_eth
[PASS] contracts_integrationtest::test_contract::test_transfer_strk
Running 0 test(s) from src/
Tests: 5 passed, 0 failed, 0 ignored, 0 filtered out
```
Compile-clean (E2030 gone) and full pass, including the 3 `#[fork("SEPOLIA_LATEST")]` tests.

**yarn format:check / scarb fmt --check:** both clean, exit 0 — no reformatting needed.

**next:check-types / yarn build:** fail, both pre- and post-deploy, but due to a **separate, pre-existing defect unrelated to this fix** — a `symbol`-typed index-signature error in `ContractUI.tsx`/`DebugContracts.tsx`/`useDeployedContractInfo.ts`/`contract.ts:56`, traced to a contract-name union mismatch (likely `vStrk`/`mainnetFork` missing from `predeployedContracts.ts` relative to `scaffold.config.ts`'s `targetNetworks: [chains.mainnetFork]`). Verified via `git stash` that this failure is present identically with or without this PR's changes — it is not a regression from this fix and is out of this PR's scope (D2/D3 only).

**next dev (port 3002):**
```
curl / -> HTTP_STATUS:200
curl /vesu -> HTTP_STATUS:200
```
Both routes render — the actual proof the frontend works, independent of the strict-build type error above.

## Test plan
- [x] `yarn compile`
- [x] `yarn test` (5/5 pass)
- [x] `yarn format:check` (clean)
- [x] `next dev` on port 3002, `curl` `/` → 200, `curl` `/vesu` → 200
- [ ] `yarn next:check-types` / `yarn build` — fails on a pre-existing, unrelated defect (see above), not introduced or fixed by this PR