### PR TITLE
Fix dead Blast RPC URLs in README setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ The tutorial is divided into the following steps:
 
 **Step 3: Full Vesu Integration** ([branch: step-3](https://github.com/Scaffold-Stark/basecamp/tree/step-3))
 
-- Introduces development on mainnet fork. Run mainnet fork: `yarn chain --fork-network https://starknet-mainnet.public.blastapi.io/rpc/v0_9`. Can follow scaffold-stark [docs](https://scaffoldstark.com/docs/recipes/DevelopingOnFork) to run and interact with a local fork of Starknet mainnet.
+- Introduces development on mainnet fork. Run mainnet fork: `yarn chain --fork-network https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_10/_hKu4IgnPgrF8O82GLuYU`. Can follow scaffold-stark [docs](https://scaffoldstark.com/docs/recipes/DevelopingOnFork) to run and interact with a local fork of Starknet mainnet.
 - To deposit or withdraw a Vesu token, you will need to interact with a "vToken", we will take vSTRK to interact
 - Use `Configure Contracts` tool to to download Vesu vStrk configures at address `0x0147ae3337b168ac9abe80a7214f0cb9e874b25c3db530a8e04beb98a134e07a` and name vStrk
 - Minor `page.tsx` and `scaffold.config.ts` updates to support mainnetFork testing
@@ -81,7 +81,7 @@ Each step builds upon the previous one, introducing new concepts and features wh
 
    ```bash
    PRIVATE_KEY_SEPOLIA=0xSOMETHING
-   RPC_URL_SEPOLIA=https://starknet-sepolia.public.blastapi.io/rpc/v0_7
+   RPC_URL_SEPOLIA=https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0_10/_hKu4IgnPgrF8O82GLuYU
    ACCOUNT_ADDRESS_SEPOLIA=0xSOMETHING
    ```
 


### PR DESCRIPTION
## Summary
Blast's public Starknet RPC endpoints have been decommissioned. Verified directly (see PR #23 on `base` for the full trace). Replaced both README references with the Alchemy endpoint this repo already ships in `packages/snfoundry/.env.example`, not a new/foreign endpoint. Identical fix to #23 (byte-identical diff, verified), so the base→step-0 cascade merge stays a no-op.

- README.md (sepolia `.env` setup snippet): `RPC_URL_SEPOLIA` — blastapi → alchemy
- README.md (step-3 mainnet fork instruction): `yarn chain --fork-network ...` — blastapi → alchemy

Only the URLs changed. `README.md` is the only file touched — it's excluded from the scaffold-stark-2 sync workflow, so this is the only channel available to fix it.

**Not included, deliberately:** `packages/nextjs/app/vesu/page.tsx:69` also has a dead Blast URL, but that file is already touched by an open PR (fix/step-3-frontend-and-cairo-test) — left alone here to avoid a conflicting edit. The Blast faucet reference (a different, live service) is untouched.

## Proof
Replacement Sepolia endpoint verified alive:
```
$ curl -X POST https://starknet-sepolia.g.alchemy.com/starknet/version/rpc/v0_10/_hKu4IgnPgrF8O82GLuYU \
  -d '{"jsonrpc":"2.0","method":"starknet_blockNumber","params":[],"id":1}'
{"id":1,"jsonrpc":"2.0","result":12719323}
```

## Test plan
- [x] `git diff --stat` — README.md only, 2 lines changed
- [x] Diffed byte-for-byte against the `base` branch fix — identical