### PR TITLE
Fix dead Blast fork URL in vesu/page.tsx comment

### DIFF
--- a/packages/nextjs/app/vesu/page.tsx
+++ b/packages/nextjs/app/vesu/page.tsx
@@ -66,7 +66,7 @@ const Home = () => {
   const { data: depositEvents } = useScaffoldEventHistory({
     contractName: "vStrk",
     eventName: "Deposit",
-    fromBlock: 1540452n, // NOTE : For now keep this block number as it is. When running local mainnet fork, use this block number as the starting block number. For example: `yarn chain --fork-network https://starknet-mainnet.public.blastapi.io/rpc/v0_9 --fork-block 1540452`
+    fromBlock: 1540452n, // NOTE : For now keep this block number as it is. When running local mainnet fork, use this block number as the starting block number. For example: `yarn chain --fork-network https://starknet-mainnet.g.alchemy.com/starknet/version/rpc/v0_10/_hKu4IgnPgrF8O82GLuYU --fork-block 1540452`
     watch: true,
     enabled: !!vStrk,
   });


### PR DESCRIPTION
## Summary
Last dead-Blast reference we own. `vesu/page.tsx:69`'s comment gives the fork command a learner copies verbatim to run the vesu lesson:
```
fromBlock: 1540452n, // NOTE : ... For example: `yarn chain --fork-network https://starknet-mainnet.public.blastapi.io/rpc/v0_9 --fork-block 1540452`
```
Blast's public Starknet RPC has been decommissioned (traced earlier: it returns a JSON-RPC error rather than a connection failure, which surfaces to a learner as `starknet-devnet` crashing with `data did not match any variant of untagged enum JsonRpcResponse` — reads like devnet is broken, not like a dead endpoint). Skipped in the earlier README-wide fix pass because PR #22 was open on this exact file; #22 is now merged, so this is the last piece.

Replaced only the URL, with the same Alchemy endpoint already merged into `README.md:50` on this branch — verified character-for-character identical. Comment text, `fromBlock: 1540452n`, and all surrounding code are untouched.

## Proof
- `git rev-parse HEAD` at branch creation: `f654e58...` (matches `origin/step-3` post-#22-merge)
- Diff: `packages/nextjs/app/vesu/page.tsx` only, exactly 1 line changed
- URL diffed against `README.md`'s merged fork URL on this same branch — character-for-character match
- `git status --short`: clean apart from the intended change

## Test plan
- [x] `git diff --stat` — 1 file, 1 line
- [x] URL matches README.md:50 exactly (diffed, not eyeballed)